### PR TITLE
Log typed arrays in abbreviated form.

### DIFF
--- a/src/debug/webgl-debug.js
+++ b/src/debug/webgl-debug.js
@@ -384,6 +384,10 @@ function glFunctionArgToString(functionName, numArgs, argumentIndex, value) {
     return "null";
   } else if (value === undefined) {
     return "undefined";
+  } else if (ArrayBuffer.isView(value)) {
+    // Large typed array views are common in WebGL APIs and create
+    // huge strings in logs.
+    return "<" + value.constructor.name + ">";
   } else {
     return value.toString();
   }


### PR DESCRIPTION
Requested by Google's MediaPipe team to keep the size of logs manageable. This does limit replay from the logs, but that wasn't guaranteed before.